### PR TITLE
fix: have current-version return biggest version if multiple tags point to a single commit

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -92,6 +92,8 @@ func (g GitSV) LastTag() string {
 		"for-each-ref",
 		fmt.Sprintf("refs/tags/%s", *g.Config.Tag.Filter),
 		"--sort",
+		"-version:refname",
+		"--sort",
 		"-creatordate",
 		"--format",
 		"%(refname:short)",


### PR DESCRIPTION
This PR fixes the issue where multiple release tags pointing to same commit doesn't return the latest tag deterministically. The issue is presented here:

```shell
$ git for-each-ref "refs/tags/v*" --sort -creatordate --format "%(refname:short) %(creatordate)" --count 5

v0.13.10 Tue Jan 7 16:27:06 2025 +0200
v0.13.11 Tue Jan 7 16:27:06 2025 +0200
v0.13.9 Tue Jan 7 16:27:06 2025 +0200
v0.13.8 Tue Jan 7 15:08:26 2025 +0200
v0.13.7 Tue Jan 7 14:55:10 2025 +0200
```

The count is here set to 5 to demonstrate the order in which the tags are returned.

The fix merely adds "-version:refname" -sort to the mix and thus always returns the biggest version number as the top result if there are multiple "latest tag" -candidates to choose from:

```shell
$ git for-each-ref "refs/tags/v*" --sort -version:refname --sort -creatordate --format "%(refname:short) %(creatordate)" --count 5

v0.13.11 Tue Jan 7 16:27:06 2025 +0200
v0.13.10 Tue Jan 7 16:27:06 2025 +0200
v0.13.9 Tue Jan 7 16:27:06 2025 +0200
v0.13.8 Tue Jan 7 15:08:26 2025 +0200
v0.13.7 Tue Jan 7 14:55:10 2025 +0200
```